### PR TITLE
Support for building in a container

### DIFF
--- a/container-build/Dockerfile
+++ b/container-build/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get -qq install -y \
     libxext-dev \
     libxi-dev \
     libxinerama-dev \
-    git
+    git && \
+    apt-get -qq clean
 
 WORKDIR /work/build
 CMD cmake .. && time make -j $(nproc)

--- a/container-build/Dockerfile
+++ b/container-build/Dockerfile
@@ -17,4 +17,4 @@ RUN apt-get -qq install -y \
     apt-get -qq clean
 
 WORKDIR /work/build
-CMD cmake .. && time make -j $(nproc)
+CMD ["bash", "-euc", "cmake .. && time make -j $(nproc)"]

--- a/container-build/Dockerfile
+++ b/container-build/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:stable
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get -qq update -y
+RUN apt-get -qq install -y \
+    cmake \
+    build-essential \
+    libx11-dev \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \
+    libsdl2-dev \
+    libxcursor-dev \
+    libxrandr-dev \
+    libxext-dev \
+    libxi-dev \
+    libxinerama-dev \
+    git
+
+WORKDIR /work/build
+CMD cmake .. && time make -j $(nproc)

--- a/container-build/README.md
+++ b/container-build/README.md
@@ -3,8 +3,11 @@
 These instructions and the accompanied script currently assume the Podman container engine,
 but Docker should work with relatively few modifications.
 
+Depending on the container runtime configuration in your system,
+you may have to run these commands as root.
+Either run all commands with root or all commands as regular user!
+
 1. Make sure you have Podman installed in your system.
-   Depending on the container runtime configuration in your system, you may have to run Podman as root.
 2. Build the image: `podman build -t ylikuutio-builder .`
 3. Build Ylikuutio using the provided script: `./run-builder.sh`
    * As with Podman, you may have to run this script as root as well.

--- a/container-build/README.md
+++ b/container-build/README.md
@@ -1,0 +1,25 @@
+# Building Ylikuutio in a container
+
+These instructions and the accompanied script currently assume the Podman container engine,
+but Docker should work with relatively few modifications.
+
+1. Make sure you have Podman installed in your system.
+   Depending on the container runtime configuration in your system, you may have to run Podman as root.
+2. Build the image: `podman build -t ylikuutio-builder .`
+3. Build Ylikuutio using the provided script: `./run-builder.sh`
+   * As with Podman, you may have to run this script as root as well.
+4. The resulting files will be located in the `../build` directory. If you ran Podman as root, the files will be owned by root.
+
+## Subsequent builds
+
+* As you make modifications to the code of the engine, you will only need to rerun step 3 of this procedure.
+* If you wish to add or remove dependencies, you must rebuild the container image (step 2),
+  then run step 3 with the command line option `--recreate` to recreate the container from the updated image.
+
+## Removing containers and images left behind
+
+If you find that building in containers is not for you, you may remove the image and container created in the
+above steps with these commands:
+
+1. `podman container rm ylikuutio-builder`
+2. `podman image rm ylikuutio-builder`

--- a/container-build/run-builder.sh
+++ b/container-build/run-builder.sh
@@ -48,7 +48,7 @@ if ! "$CONTAINER_ENGINE" container exists ylikuutio-builder; then
         --cpus $(($(nproc) - 1)) \
         --volume "$BUILD_DIR:/work/build:rw" \
         --volume "$REPO_DIR:/work:ro" \
-        ylikuutio-builder \ # image name
+        ylikuutio-builder \
         > /dev/null
 fi
 

--- a/container-build/run-builder.sh
+++ b/container-build/run-builder.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
 usage() {
     echo "Usage: ./run-builder.sh [[-r|--recreate] | [-h|--help]]"
@@ -14,13 +14,11 @@ usage() {
 CONTAINER_ENGINE="podman"
 RECREATE=0
 
-while [[ -v 1 && "$1" != "" ]]; do
+while [[ -z ${var+x} && "$1" != "" ]]; do
     case "$1" in
-        -r | --recreate )   shift
-                            RECREATE=1
+        -r | --recreate )   RECREATE=1
                             ;;
-        -h | --help )       shift
-                            usage
+        -h | --help )       usage
                             exit
                             ;;
         * )                 usage

--- a/container-build/run-builder.sh
+++ b/container-build/run-builder.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 usage() {
     echo "Usage: ./run-builder.sh [[-r|--recreate] | [-h|--help]]"
     echo

--- a/container-build/run-builder.sh
+++ b/container-build/run-builder.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+usage() {
+    echo "Usage: ./run-builder.sh [[-r|--recreate] | [-h|--help]]"
+    echo
+    echo "-r | --recreate   Force recreation of container before building."
+    echo "                  This is useful after rebuilding the image."
+    echo
+    echo "-h | --help       Display this message."
+}
+
+CONTAINER_ENGINE="podman"
+RECREATE=0
+
+while [ "$1" != "" ]; do
+    case "$1" in
+        -r | --recreate )   shift
+                            recreate=1
+                            ;;
+        -h | --help )       shift
+                            usage
+                            exit
+                            ;;
+        * )                 usage
+                            exit 1
+    esac
+    shift
+done
+
+THIS_DIR=$(dirname "$(readlink -f "$0")")
+REPO_DIR="$THIS_DIR/.."
+BUILD_DIR="$REPO_DIR/build"
+# create build directory if it does not exist
+[[ ! -e "$BUILD_DIR" ]] && mkdir "$BUILD_DIR"
+
+if [ $RECREATE == 1 ] && "$CONTAINER_ENGINE" container exists ylikuutio-builder; then
+    echo "--- Forced recreation, deleting container..."
+    "$CONTAINER_ENGINE" container rm ylikuutio-builder > /dev/null
+fi
+
+# create container if it does not exist
+if ! "$CONTAINER_ENGINE" container exists ylikuutio-builder; then
+    echo "--- Creating container..."
+    "$CONTAINER_ENGINE" container create \
+        --attach stdout \
+        --attach stderr \
+        --name ylikuutio-builder \
+        --cpus $(($(nproc) - 1)) \
+        --volume "$BUILD_DIR:/work/build:rw" \
+        --volume "$REPO_DIR:/work:ro" \
+        ylikuutio-builder \ # image name
+        > /dev/null
+fi
+
+echo "--- Starting build..."
+"$CONTAINER_ENGINE" container start -a ylikuutio-builder

--- a/container-build/run-builder.sh
+++ b/container-build/run-builder.sh
@@ -14,7 +14,7 @@ usage() {
 CONTAINER_ENGINE="podman"
 RECREATE=0
 
-while [ "$1" != "" ]; do
+while [[ -v 1 && "$1" != "" ]]; do
     case "$1" in
         -r | --recreate )   shift
                             RECREATE=1

--- a/container-build/run-builder.sh
+++ b/container-build/run-builder.sh
@@ -46,8 +46,8 @@ if ! "$CONTAINER_ENGINE" container exists ylikuutio-builder; then
         --attach stderr \
         --name ylikuutio-builder \
         --cpus $(($(nproc) - 1)) \
-        --volume "$BUILD_DIR:/work/build:rw" \
-        --volume "$REPO_DIR:/work:ro" \
+        --volume "$BUILD_DIR:/work/build:rw,z" \
+        --volume "$REPO_DIR:/work:ro,z" \
         ylikuutio-builder \
         > /dev/null
 fi

--- a/container-build/run-builder.sh
+++ b/container-build/run-builder.sh
@@ -15,7 +15,7 @@ RECREATE=0
 while [ "$1" != "" ]; do
     case "$1" in
         -r | --recreate )   shift
-                            recreate=1
+                            RECREATE=1
                             ;;
         -h | --help )       shift
                             usage


### PR DESCRIPTION
Dockerfile, script and some documentation for building the Ylikuutio
engine in a Linux container. Currently only supports the GCC Linux
build, but easily adapted for Clang or cross-compilation targets.